### PR TITLE
Bug/read forecast start utc

### DIFF
--- a/sdk/python/pvsite_datamodel/read/latest_forecast_values.py
+++ b/sdk/python/pvsite_datamodel/read/latest_forecast_values.py
@@ -24,9 +24,10 @@ def get_latest_forecast_values_by_site(
 
     # start main query
     query: Query = session.query(LatestForecastValueSQL)
+    query = query.join(DatetimeIntervalSQL)
 
     if start_utc is not None:
-        query = query.filter(LatestForecastValueSQL.target_time >= start_utc)
+        query = query.filter(DatetimeIntervalSQL.start_utc >= start_utc)
 
         # also filter on creation time, to speed up things
         created_utc_filter = start_utc - dt.timedelta(days=1)
@@ -38,7 +39,6 @@ def get_latest_forecast_values_by_site(
     query = query.where(LatestForecastValueSQL.site_uuid.in_(site_uuids))
 
     # order by site, target time and created time desc
-    query.join(DatetimeIntervalSQL)
     query.order_by(
         LatestForecastValueSQL.site_uuid,
         DatetimeIntervalSQL.start_utc,

--- a/sdk/python/tests/test_read.py
+++ b/sdk/python/tests/test_read.py
@@ -176,10 +176,16 @@ class TestGetLatestForecastValuesBySite:
         latest_forecast_values = get_latest_forecast_values_by_site(
             session=db_session,
             site_uuids=[site.site_uuid],
-            start_utc=dt.datetime.today() - dt.timedelta(minutes=60)
+            start_utc=dt.datetime.today() - dt.timedelta(minutes=7)
         )
+        assert len(latest_forecast_values[site.site_uuid]) == 7
 
-        assert len(latest_forecast_values) == len(site)
+        latest_forecast_values = get_latest_forecast_values_by_site(
+            session=db_session,
+            site_uuids=[site.site_uuid],
+            start_utc=dt.datetime.today() - dt.timedelta(minutes=5)
+        )
+        assert len(latest_forecast_values[site.site_uuid]) == 5
 
 
 class TestFilterQueryByDatetimeInterval:

--- a/sdk/python/tests/test_read.py
+++ b/sdk/python/tests/test_read.py
@@ -168,6 +168,19 @@ class TestGetLatestForecastValuesBySite:
 
         assert len(latest_forecast_values) == len(sites)
 
+    def test_gets_latest_forecast_values_filter_start_utc(
+            self, latestforecastvalues, db_session):
+        query: Query = db_session.query(SiteSQL)
+        site: SiteSQL = query.first()
+
+        latest_forecast_values = get_latest_forecast_values_by_site(
+            session=db_session,
+            site_uuids=[site.site_uuid],
+            start_utc=dt.datetime.today() - dt.timedelta(minutes=60)
+        )
+
+        assert len(latest_forecast_values) == len(site)
+
 
 class TestFilterQueryByDatetimeInterval:
     """Tests for the filter_query_by_datetime_interval function"""


### PR DESCRIPTION
# Pull Request

## Description

Fix for filtering get last forecast value

## How Has This Been Tested?

added a test

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
