### PR TITLE
add datetime_interval relationship

### DIFF
--- a/sdk/python/pvsite_datamodel/sqlmodels.py
+++ b/sdk/python/pvsite_datamodel/sqlmodels.py
@@ -1,6 +1,8 @@
 """
 SQLAlchemy definition of the pvsite database schema
 """
+from __future__ import annotations
+# This means we can use Typing of objects that have jet to be defined
 
 import uuid
 from datetime import datetime

--- a/sdk/python/pvsite_datamodel/sqlmodels.py
+++ b/sdk/python/pvsite_datamodel/sqlmodels.py
@@ -175,6 +175,7 @@ class LatestForecastValueSQL(Base, CreatedMixin):
     forecast_version = sa.Column(sa.String(32), nullable=False)
 
     latest_forecast: SiteSQL = relationship("SiteSQL", back_populates="latest_forecast_values")
+    datetime_interval: DatetimeIntervalSQL = relationship("DatetimeIntervalSQL", back_populates="latest_forecast_values")
 
 
 class ClientSQL(Base, CreatedMixin):

--- a/sdk/python/tests/test_read.py
+++ b/sdk/python/tests/test_read.py
@@ -155,6 +155,7 @@ class TestGetLatestForecastValuesBySite:
 
         assert len(latest_forecast_values) == 1
         assert len(latest_forecast_values[site.site_uuid]) == 10
+        assert latest_forecast_values[site.site_uuid][0].datetime_interval is not None
 
     def test_gets_latest_forecast_values_with_multiple_sites(
             self, latestforecastvalues, db_session):


### PR DESCRIPTION
# Pull Request

## Description

add datetime_interval relationship on last_forecast object

This helps for https://github.com/openclimatefix/PVSiteAPI/issues/24

## How Has This Been Tested?

normal CI + added something to a test

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
