### PR TITLE
Remove conversion of datetime string from forecast function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: "v0.0.236"
     hooks:
       - id: ruff
-        files: sdk/python/pvsite_datamodel
+        files: sdk/python
         args: [--fix, -v]
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/sdk/python/pvsite_datamodel/read/site.py
+++ b/sdk/python/pvsite_datamodel/read/site.py
@@ -51,7 +51,7 @@ def get_site_by_client_site_id(session: Session, client_name: str, client_site_i
     site: Optional[SiteSQL] = query.first()
 
     if site is None:
-        raise Exception(f"Could not find site {client_site_id} from client {client_name}")
+        raise KeyError(f"Could not find site {client_site_id} from client {client_name}")
 
     return site
 

--- a/sdk/python/pvsite_datamodel/schema.py
+++ b/sdk/python/pvsite_datamodel/schema.py
@@ -10,6 +10,8 @@ from pandera.typing import Series
 class InputForecastValuesSchema(pa.SchemaModel):
     """Schema defining the makeup of the input forecast values dataframe."""
 
+    # TODO: utilise this
+
     target_datetime_utc: Series[DateTime] = pa.Field()
     forecast_kw: Series[Float] = pa.Field(ge=0)
     pv_uuid: Series[String] = pa.Field(le=32)

--- a/sdk/python/pvsite_datamodel/sqlmodels.py
+++ b/sdk/python/pvsite_datamodel/sqlmodels.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 # This means we can use Typing of objects that have jet to be defined
-
 import uuid
 from datetime import datetime
 from typing import List

--- a/sdk/python/pvsite_datamodel/write/forecast.py
+++ b/sdk/python/pvsite_datamodel/write/forecast.py
@@ -4,7 +4,6 @@ import datetime as dt
 import logging
 import uuid
 
-import dateutil.parser as dp
 import numpy.typing as npt
 import pandas as pd
 import sqlalchemy.orm as sa_orm
@@ -63,11 +62,9 @@ def insert_forecast_values(
 
         # For each target time:
         for target_time in target_times:
-            # Convert the target_time string to a datetime object
-            target_time_as_datetime: dt.datetime = dp.isoparse(target_time)
 
             datetime_interval, newly_added_rows = get_or_else_create_datetime_interval(
-                session=session, start_time=target_time_as_datetime
+                session=session, start_time=target_time
             )
             written_rows.extend(newly_added_rows)
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -63,6 +63,8 @@ exclude = ["__init__.py"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402"]
+"tests/*" = ["S101", "D102", "D103", "PT004"]
+"setup.py" = ["D100"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -63,7 +63,7 @@ exclude = ["__init__.py"]
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402"]
-"tests/*" = ["S101", "D102", "D103", "PT004"]
+"tests/*" = ["S101", "D102", "D103", "PT004", "PT012"]
 "setup.py" = ["D100"]
 
 [tool.pytest.ini_options]

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from setuptools import setup
 
 this_directory = Path(__file__).parent

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -1,6 +1,5 @@
 """ Pytest fixtures for tests """
-from datetime import datetime, timedelta, timezone
-
+import datetime as dt
 import pytest
 import uuid
 
@@ -64,7 +63,7 @@ def sites(db_session):
         client = ClientSQL(
             client_uuid=uuid.uuid4(),
             client_name=f"testclient_{i}",
-            created_utc=datetime.now(timezone.utc),
+            created_utc=dt.datetime.now(dt.timezone.utc),
         )
         site = SiteSQL(
             site_uuid=uuid.uuid4(),
@@ -73,8 +72,8 @@ def sites(db_session):
             latitude=51,
             longitude=3,
             capacity_kw=4,
-            created_utc=datetime.now(timezone.utc),
-            updated_utc=datetime.now(timezone.utc),
+            created_utc=dt.datetime.now(dt.timezone.utc),
+            updated_utc=dt.datetime.now(dt.timezone.utc),
             ml_id=i,
         )
         db_session.add(client)
@@ -90,7 +89,7 @@ def sites(db_session):
 def generations(db_session, sites):
     """Create some fake generations"""
 
-    start_times = [datetime.today() - timedelta(minutes=x) for x in range(10)]
+    start_times = [dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=x) for x in range(10)]
 
     all_generations = []
     for site in sites:
@@ -117,7 +116,7 @@ def latestforecastvalues(db_session, sites):
 
     latest_forecast_values = []
     forecast_version: str = "0.0.0"
-    start_times = [datetime.today() - timedelta(minutes=x) for x in range(10)]
+    start_times = [dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=x) for x in range(10)]
 
     for site in sites:
         forecast: ForecastSQL = ForecastSQL(
@@ -185,7 +184,7 @@ def forecast_values(db_session, sites):
 def datetimeintervals(db_session):
     """Create fake datetime intervals"""
 
-    start_times: List[datetime] = [datetime.today() - timedelta(minutes=x) for x in range(10)]
+    start_times: List[dt.datetime] = [dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=x) for x in range(10)]
 
     for time in start_times:
         get_or_else_create_datetime_interval(session=db_session, start_time=time)
@@ -193,7 +192,7 @@ def datetimeintervals(db_session):
 
 @pytest.fixture()
 def test_time():
-    return datetime(2022, 7, 25, 0, 0, 0, 0, timezone.utc)
+    return dt.datetime(2022, 7, 25, 0, 0, 0, 0, dt.timezone.utc)
 
 
 @pytest.fixture()
@@ -201,9 +200,7 @@ def forecast_valid_site(sites):
     site_uuid = sites[0].site_uuid
 
     return {
-        "target_datetime_utc": [
-            (datetime.today() - timedelta(minutes=x)).isoformat() for x in range(10)
-        ],
+        "target_datetime_utc": [dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=x) for x in range(10)],
         "forecast_kw": [float(x) for x in range(10)],
         "pv_uuid": [site_uuid for x in range(10)],
     }
@@ -212,7 +209,7 @@ def forecast_valid_site(sites):
 @pytest.fixture()
 def forecast_invalid_site():
     return {
-        "target_datetime_utc": [datetime.today().isoformat()],
+        "target_datetime_utc": [dt.datetime.now(dt.timezone.utc)],
         "forecast_kw": [1.0],
         "pv_uuid": [uuid.uuid4()],
     }
@@ -223,16 +220,16 @@ def generation_valid_site(sites):
     site_uuid = sites[0].site_uuid
 
     return {
-        "start_datetime_utc": [(datetime.today() - timedelta(minutes=x)) for x in range(10)],
+        "start_datetime_utc": [dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=x) for x in range(10)],
         "power_kw": [float(x) for x in range(10)],
-        "site_uuid": [site_uuid for x in range(10)],
+        "site_uuid": [site_uuid for _ in range(10)],
     }
 
 
 @pytest.fixture()
 def generation_invalid_site():
     return {
-        "start_datetime_utc": [datetime.today()],
+        "start_datetime_utc": [dt.datetime.now(dt.timezone.utc)],
         "power_kw": [1.0],
         "site_uuid": [uuid.uuid4()],
     }

--- a/sdk/python/tests/test_read.py
+++ b/sdk/python/tests/test_read.py
@@ -1,26 +1,27 @@
-""" Test read functions """
+"""Test read functions."""
 
 import datetime as dt
 import uuid
-
-from sqlalchemy.orm import Query
 from typing import List
 
-from pvsite_datamodel import SiteSQL, StatusSQL, ClientSQL, DatetimeIntervalSQL
-from pvsite_datamodel.read import get_all_sites
-from pvsite_datamodel.read import get_site_by_uuid
-from pvsite_datamodel.read import get_site_by_client_site_id
-from pvsite_datamodel.read import get_pv_generation_by_sites
-from pvsite_datamodel.read import get_latest_status
-from pvsite_datamodel.read import get_pv_generation_by_client
-from pvsite_datamodel.read import get_latest_forecast_values_by_site
-from pvsite_datamodel.read.utils import filter_query_by_datetime_interval
-
 import pytest
+from sqlalchemy.orm import Query
+
+from pvsite_datamodel import ClientSQL, DatetimeIntervalSQL, SiteSQL, StatusSQL
+from pvsite_datamodel.read import (
+    get_all_sites,
+    get_latest_forecast_values_by_site,
+    get_latest_status,
+    get_pv_generation_by_client,
+    get_pv_generation_by_sites,
+    get_site_by_client_site_id,
+    get_site_by_uuid,
+)
+from pvsite_datamodel.read.utils import filter_query_by_datetime_interval
 
 
 class TestGetAllSites:
-    """Tests for the get_all_sites function"""
+    """Tests for the get_all_sites function."""
 
     def test_returns_all_sites(self, sites, db_session):
         out = get_all_sites(db_session)
@@ -30,7 +31,7 @@ class TestGetAllSites:
 
 
 class TestGetSiteByUUID:
-    """Tests for the get_site_by_uuid function"""
+    """Tests for the get_site_by_uuid function."""
 
     def tests_gets_site_for_existing_uuid(self, sites, db_session):
         site = get_site_by_uuid(session=db_session, site_uuid=sites[0].site_uuid)
@@ -38,12 +39,12 @@ class TestGetSiteByUUID:
         assert site == sites[0]
 
     def test_raises_error_for_nonexistant_site(self, sites, db_session):
-        with pytest.raises(Exception):
+        with pytest.raises(KeyError):
             _ = get_site_by_uuid(session=db_session, site_uuid=uuid.uuid4())
 
 
 class TestGetSiteByClientSiteID:
-    """Tests for the get_site_by_client_site_id function"""
+    """Tests for the get_site_by_client_site_id function."""
 
     def test_gets_site_successfully(self, sites, db_session):
         site = get_site_by_client_site_id(
@@ -55,7 +56,7 @@ class TestGetSiteByClientSiteID:
         assert site.client_site_id == 1
 
     def test_raises_exception_when_no_such_site_exists(self, sites, db_session):
-        with pytest.raises(Exception):
+        with pytest.raises(KeyError):
             _ = get_site_by_client_site_id(
                 session=db_session,
                 client_name="testclient_100",
@@ -64,7 +65,7 @@ class TestGetSiteByClientSiteID:
 
 
 class TestGetPVGenerationByClient:
-    """Tests for the get_pv_generation_by_client function"""
+    """Tests for the get_pv_generation_by_client function."""
 
     def test_returns_all_generations_without_input_client(self, generations, db_session):
         generations = get_pv_generation_by_client(session=db_session)
@@ -99,7 +100,7 @@ class TestGetPVGenerationByClient:
 
 
 class TestGetPVGenerationBySites:
-    """Tests for the get_pv_generation_by_sites function"""
+    """Tests for the get_pv_generation_by_sites function."""
 
     def test_gets_generation_for_single_input_site(self, generations, db_session):
         query: Query = db_session.query(SiteSQL)
@@ -135,7 +136,7 @@ class TestGetPVGenerationBySites:
 
 
 class TestGetLatestStatus:
-    """Tests for the get_latest_status function"""
+    """Tests for the get_latest_status function."""
 
     def test_gets_latest_status_when_exists(self, statuses, db_session):
         status: StatusSQL = get_latest_status(db_session)
@@ -144,7 +145,7 @@ class TestGetLatestStatus:
 
 
 class TestGetLatestForecastValuesBySite:
-    """Tests for the get_latest_forecast_values_by_site function"""
+    """Tests for the get_latest_forecast_values_by_site function."""
 
     def test_gets_latest_forecast_values_with_single_site(self, latestforecastvalues, db_session):
         query: Query = db_session.query(SiteSQL)
@@ -192,7 +193,7 @@ class TestGetLatestForecastValuesBySite:
 
 
 class TestFilterQueryByDatetimeInterval:
-    """Tests for the filter_query_by_datetime_interval function"""
+    """Tests for the filter_query_by_datetime_interval function."""
 
     def test_returns_datetime_intervals_in_filter(self, datetimeintervals, db_session):
         query: Query = db_session.query(DatetimeIntervalSQL)

--- a/sdk/python/tests/test_write.py
+++ b/sdk/python/tests/test_write.py
@@ -1,24 +1,22 @@
-"""Test write functions"""
+"""Test write functions."""
 
 import pandas as pd
 import pytest
 
+from pvsite_datamodel import DatabaseConnection
 from pvsite_datamodel.sqlmodels import (
-    SiteSQL,
     DatetimeIntervalSQL,
     ForecastSQL,
     ForecastValueSQL,
     GenerationSQL,
+    SiteSQL,
 )
-
-from pvsite_datamodel import DatabaseConnection
+from pvsite_datamodel.write import insert_forecast_values, insert_generation_values
 from pvsite_datamodel.write.datetime_intervals import get_or_else_create_datetime_interval
-from pvsite_datamodel.write import insert_forecast_values
-from pvsite_datamodel.write import insert_generation_values
 
 
 class TestDatabaseConnection:
-    """Tests for the DatabaseConnection class"""
+    """Tests for the DatabaseConnection class."""
 
     def test_connection(self, engine, sites):
         dbcon = DatabaseConnection(engine.url, echo=False)
@@ -27,7 +25,7 @@ class TestDatabaseConnection:
 
 
 class TestGetOrElseCreateDatetimeInterval:
-    """Tests for the get_or_else_create_datetime_interval function"""
+    """Tests for the get_or_else_create_datetime_interval function."""
 
     def test_writes_interval_when_not_exists(self, db_session, test_time):
         # Call function with test_time
@@ -59,7 +57,7 @@ class TestGetOrElseCreateDatetimeInterval:
 
 
 class TestInsertForecastValues:
-    """Tests for the insert_forecast_values function"""
+    """Tests for the insert_forecast_values function."""
 
     def test_inserts_values_for_existing_site(self, db_session, forecast_valid_site):
         df = pd.DataFrame(forecast_valid_site)
@@ -79,10 +77,7 @@ class TestInsertForecastValues:
     def test_inserts_values_for_existing_site_and_existing_datetime_intervals(
             self, db_session, forecast_valid_site
     ):
-        """
-        Tests inserts values successfully without creating redundant datetime intervals
-        """
-
+        """Tests inserts values successfully without creating redundant datetime intervals."""
         # Create DataFrame and write to DB
         df = pd.DataFrame(forecast_valid_site)
         # write once and again,
@@ -101,20 +96,18 @@ class TestInsertForecastValues:
         assert len(written_forecasts) == 2  # 1 more since previous test
 
     def test_errors_on_invalid_site(self, db_session, forecast_invalid_site):
-        """Tests function errors when incoming pv_uuid does not exist in sites table"""
-
+        """Tests function errors when incoming pv_uuid does not exist in sites table."""
         df = pd.DataFrame(forecast_invalid_site)
         with pytest.raises(KeyError):
             written_rows = insert_forecast_values(session=db_session, df_forecast_values=df)
-            assert len(written_rows), 0
+        assert len(written_rows), 0
 
 
 class TestInsertGenerationValues:
-    """Tests for the insert_generation_values function"""
+    """Tests for the insert_generation_values function."""
 
     def test_inserts_generation_for_existing_site(self, db_session, generation_valid_site):
-        """Tests inserts values successfully"""
-
+        """Tests inserts values successfully."""
         df = pd.DataFrame(generation_valid_site)
         written_rows = insert_generation_values(session=db_session, generation_values_df=df)
 

--- a/sdk/python/tests/test_write.py
+++ b/sdk/python/tests/test_write.py
@@ -100,7 +100,7 @@ class TestInsertForecastValues:
         df = pd.DataFrame(forecast_invalid_site)
         with pytest.raises(KeyError):
             written_rows = insert_forecast_values(session=db_session, df_forecast_values=df)
-        assert len(written_rows), 0
+            assert len(written_rows) == 0
 
 
 class TestInsertGenerationValues:


### PR DESCRIPTION
Incoming dataframe will have datetime objects in the 'target_datetime_utc' column, so remove the parsing occuring in the forecast function.
